### PR TITLE
Fix commands generated by docker:compose:env task

### DIFF
--- a/lib/docker/compose/rake_tasks.rb
+++ b/lib/docker/compose/rake_tasks.rb
@@ -27,15 +27,19 @@ module Docker::Compose
         namespace :compose do
           desc 'Print bash exports with IP/ports of running containers'
           task :env do
+            commands = []
             mapper = Docker::Compose::Mapper.new(@session,
                                                  @net_info.docker_routable_ip)
             self.env.each_pair do |k, v|
               begin
-                puts format('export %s=%s;', k, mapper.map(v))
+                commands << format('export %s=%s;', k, mapper.map(v))
               rescue Docker::Compose::Mapper::NoService
-                puts format('unset %s; # service not running', k)
+                commands << format('unset %s; # service not running', k)
               end
             end
+            # Ensure that we export first, so that any unset commands do not
+            # unset the variables we are trying to export
+            puts commands.sort.join("\n")
           end
         end
       end

--- a/lib/docker/compose/rake_tasks.rb
+++ b/lib/docker/compose/rake_tasks.rb
@@ -31,9 +31,9 @@ module Docker::Compose
                                                  @net_info.docker_routable_ip)
             self.env.each_pair do |k, v|
               begin
-                puts format('export %s=%s', k, mapper.map(v))
+                puts format('export %s=%s;', k, mapper.map(v))
               rescue Docker::Compose::Mapper::NoService
-                puts format('unset %s # service not running', k)
+                puts format('unset %s; # service not running', k)
               end
             end
           end


### PR DESCRIPTION
Each line needs to be separated by ; to ensure they are evaluated independently when run with:
eval $(bundle exec rake docker:compose:env)